### PR TITLE
fix(cli): rework the cli to properly handle stdin and improve tests

### DIFF
--- a/bin/enchinito.cli.js
+++ b/bin/enchinito.cli.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 import readline from 'readline';
 import { stdin, argv } from 'process';
+import fs from 'fs';
 // eslint-disable-next-line import/extensions
-import { enchinito } from '../src/enchinito.js';
+import { enchinito } from '../lib/esm/enchinito.js';
 
-const { log, error } = console;
-const rawArgs = argv.slice(2);
-const helpRegex = /^(-+|\/)(h(elp)?|\?)$/gi;
+const { log } = console;
+const args = argv.slice(2);
 const helpMessage = (_log = log) => {
-  _log(`USAGE: enchinito <string>
+  _log(`USAGE: enchinito [STRING]
 
         Say it en chinito.
 
@@ -19,13 +19,22 @@ OPTIONS:
             as a list (separated by line breaks) for easier processing.
         -h, --help:
             Display this message.
+        -v, --version:
+            Output version information and exit.
 `);
 };
-let showHelp = false;
-let unknownOption = false;
 
-// read from stdin
-if (stdin.isTTY !== true) {
+if (args.indexOf('--help') !== -1 || args.indexOf('-h') !== -1) {
+  helpMessage();
+  process.exit(0);
+}
+
+if (args.indexOf('--version') !== -1 || args.indexOf('-v') !== -1) {
+  log(`v${JSON.parse(fs.readFileSync('package.json', 'utf8')).version}`);
+  process.exit(0);
+}
+
+if (args.length === 0) {
   stdin.setEncoding('utf8');
   const input = readline.createInterface({ input: stdin });
   input
@@ -36,36 +45,7 @@ if (stdin.isTTY !== true) {
       process.exit(0);
     });
 } else {
-  const txt = rawArgs
-    .filter((arg) => {
-      if (helpRegex.exec(arg) !== null) {
-        showHelp = true;
-        return false;
-      }
-      if (arg.startsWith('-')) {
-        unknownOption = true;
-        return false;
-      }
-      return typeof arg === 'string';
-    })
-    .map((arg) => arg.trim());
-
-  if (
-    unknownOption ||
-    (rawArgs.length > 1 && txt.length === 0 && showHelp === false)
-  ) {
-    error(`ERROR: I don't know that to do with that.`);
-    helpMessage(error);
-    process.exit(1);
-  }
-
-  if (showHelp && txt.length === 0) {
-    helpMessage();
-    process.exit(0);
-  }
-
-  txt.forEach((arg) => {
+  args.forEach((arg) => {
     log(`${enchinito(arg)} `);
   });
-  process.exit(0);
 }

--- a/bin/enchinito.cli.test.js
+++ b/bin/enchinito.cli.test.js
@@ -1,33 +1,40 @@
 import { spawn } from 'child_process';
 import path from 'path';
+import fs from 'fs';
 
 const filePath = `${path.resolve('bin/enchinito.cli.js')}`;
+
+test('--version', () => {
+  const enchinito = spawn('node', [filePath, '-v']);
+  const expectedVersion = `v${
+    JSON.parse(fs.readFileSync('package.json', 'utf8')).version
+  }`;
+  enchinito.stdout.on('data', (data) => {
+    expect(data.toString()).toMatch(expectedVersion);
+  });
+});
 
 test('it helps', () => {
   const enchinito = spawn('node', [filePath, '-h']);
   enchinito.stdout.on('data', (data) => {
-    expect(data.stdout).toContain('USAGE: enchinito <string>');
+    expect(data.toString()).toContain('USAGE: enchinito [STRING]');
   });
-  enchinito.kill('SIGKILL');
 });
 
 test('it speaks', () => {
   const input = 'Bonne fête des Mères! 🎉';
   const enchinito = spawn('node', [filePath, input]);
   enchinito.stdout.on('data', (data) => {
-    expect(data.stdout).toBe('Binni fîti dis Mìris! 🎉\n');
+    expect(data.toString()).toMatch('Binni fîti dis Mìris! 🎉');
   });
-  enchinito.kill('SIGKILL');
 });
 
 test('it pipes', () => {
   const input = 'Bonne fête des Mères! 🎉';
-  const echo = spawn('echo', [input]);
   const enchinito = spawn('node', [filePath]);
-
-  enchinito.stdout.pipe(echo.stdin);
   enchinito.stdout.on('data', (data) => {
-    expect(data.stdout).toBe('Binni fîti dis Mìris! 🎉\n');
+    expect(data.toString()).toMatch('Binni fîti dis Mìris! 🎉');
   });
-  enchinito.kill('SIGKILL');
+  enchinito.stdin.write(input);
+  enchinito.stdin.end();
 });


### PR DESCRIPTION
`process.stdin.isTTY` is not reliable, a better approach seems to be to fallback to read stdin when
all other options have been discarded.

The cli script now uses the esm module located in the lib folder, instead of the one in src.